### PR TITLE
On panic, display the source sql line number which caused the panic

### DIFF
--- a/adapters/pg.js
+++ b/adapters/pg.js
@@ -13,6 +13,10 @@ module.exports = {
             client.query(query, values, function(err, result) {
                 //call `done()` to release the client back to the pool
                 done();
+                //add the sql line number to the error output if available
+                if (err && err.position) {
+                  err.sql_line = (query.substring(0, err.position).match(/\n/g) || []).length + 1;
+                }
                 err && utils.panic(err);
                 cb(result);
             });


### PR DESCRIPTION
If the error has a query and position associated:
h/t https://github.com/brianc/node-postgres/issues/969#issuecomment-201017054

This is handy as the standard output is, eg below, does not say have any way of finding where the problem was in the migration - line below is in the postgres C++ src files:
```
ERROR: { error: YOUR ERROR
    at Connection.parseE (/Users/ben/Development/hvmn/introspect-api/node_modules/pg/lib/connection.js:539:11)
    at Connection.parseMessage (/Users/ben/Development/hvmn/introspect-api/node_modules/pg/lib/connection.js:366:17)
    at Socket.<anonymous> (/Users/ben/Development/hvmn/introspect-api/node_modules/pg/lib/connection.js:105:22)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at addChunk (_stream_readable.js:250:12)
    at readableAddChunk (_stream_readable.js:237:11)
    at Socket.Readable.push (_stream_readable.js:195:10)
    at TCP.onread (net.js:588:20)
  name: 'error',
  length: 107,
  severity: 'ERROR',
  code: '42601',
  detail: undefined,
  hint: undefined,
  position: '186',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'pl_gram.y',
  line: '2514',
  routine: 'word_is_not_variable' }
```