### PR TITLE
Adding a better error message when migrationsDir is missing on config

### DIFF
--- a/commands/create-migration-command.js
+++ b/commands/create-migration-command.js
@@ -6,6 +6,10 @@ module.exports = function (config, logger, migrationName) {
     var up, down,
         ts = Date.now();
 
+    if (typeof config.migrationsDir !== 'string') {
+        throw new Error('configuration "migrationsDir" is missing');
+    }
+
     mkdirp.sync(config.migrationsDir);
 
     up = ts + '_up_' + migrationName + '.sql';


### PR DESCRIPTION
from:
```
path.js:39
    throw new ERR_INVALID_ARG_TYPE('path', 'string', path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at assertPath (path.js:39:11)
    at Object.resolve (path.js:1090:7)
    at Function.sync (/Users/andrefarzat/Documents/vivo-gaus/node_modules/mkdirp/index.js:68:14)
    at module.exports (/Users/andrefarzat/Documents/vivo-gaus/node_modules/sql-migrations/commands/create-migration-command.js:9:12)
    at Object.run (/Users/andrefarzat/Documents/vivo-gaus/node_modules/sql-migrations/index.js:46:17)
    at Object.<anonymous> (/Users/andrefarzat/Documents/vivo-gaus/bin/migration:5:27)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
```

to:
```
/Users/andrefarzat/Documents/vivo-gaus/node_modules/sql-migrations/commands/create-migration-command.js:10
    throw new Error('configuration "migrationsDir" is missing');
    ^

Error: configuration "migrationsDir" is missing
    at module.exports (/Users/andrefarzat/Documents/vivo-gaus/node_modules/sql-migrations/commands/create-migration-command.js:10:15)
    at Object.run (/Users/andrefarzat/Documents/vivo-gaus/node_modules/sql-migrations/index.js:46:17)
    at Object.<anonymous> (/Users/andrefarzat/Documents/vivo-gaus/bin/migration:5:27)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:236:19)
```

Now at least it's possible to know that it's a missing configuration 😸 