### PR TITLE
Add an option of selecting initial migration time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ var configuration = {
     // Parameters are optional. If you provide them then any occurrences of the parameter (i.e. FOO) in the SQL scripts will be replaced by the value (i.e. bar).
     parameters: {
         "FOO": "bar"
-    }
+    },
+    minMigrationTime: new Date('2018-01-01').getTime() // Optional. Skip migrations before this before this time.
 };
 ```
 

--- a/commands/run-migrations-command.js
+++ b/commands/run-migrations-command.js
@@ -1,10 +1,10 @@
 var chalk = require('chalk');
 
-module.exports = function (migrationProvider, adapter, logger) {
+module.exports = function (migrationProvider, adapter, minMigrationTime, logger) {
     return adapter.appliedMigrations()
         .then(function (appliedMigrationIds) {
             var migrationsList = migrationProvider.getMigrationsList();
-            var pending = getPending(migrationsList, appliedMigrationIds);
+            var pending = getPending(migrationsList, appliedMigrationIds, minMigrationTime);
 
             if (pending.length === 0) {
                 logger.log('No pending migrations');
@@ -30,11 +30,11 @@ module.exports = function (migrationProvider, adapter, logger) {
         });
 };
 
-function getPending(migrationsList, appliedMigrationIds) {
+function getPending(migrationsList, appliedMigrationIds, minMigrationTime) {
     var pending = [];
     migrationsList.forEach(function (migration) {
         var id = migration.match(/^(\d+)/)[0];
-        if (!~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
+        if (id >= minMigrationTime && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
             pending.push(migration);
         }
     });

--- a/commands/run-migrations-command.js
+++ b/commands/run-migrations-command.js
@@ -34,7 +34,7 @@ function getPending(migrationsList, appliedMigrationIds, minMigrationTime) {
     var pending = [];
     migrationsList.forEach(function (migration) {
         var id = migration.match(/^(\d+)/)[0];
-        if (id >= minMigrationTime && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
+        if ((!minMigrationTime || id >= minMigrationTime) && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
             pending.push(migration);
         }
     });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var LOGGER = console;
 function migrate(config) {
     var migrationProvider = MigrationProvider(config);
     var adapter = PgAdapter(config, LOGGER);
-    return runMigrationsCommand(migrationProvider, adapter, LOGGER).then(function () {
+    return runMigrationsCommand(migrationProvider, adapter, config.minMigrationTime, LOGGER).then(function () {
         return adapter.dispose();
     }, function (error) {
         function rethrowOriginalError() {


### PR DESCRIPTION
It's an option to configure a time for "skipping" migrations which occurred  before this time. It helps , in my case, when you want to start using this pack and you want to integrate to old migrations.

Thanks