### PR TITLE
Update migrate.js to use process.cwd

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 require('./').run({
-    migrationsDir: path.resolve(__dirname, 'migrations'),
+    migrationsDir: path.resolve(process.cwd, 'migrations'),
     user: 'dabramov',
     host: 'localhost',
     db: 'sql_migrations',


### PR DESCRIPTION
__dirname always creates the migrations relative to this node module. Using process.cwd allows consumers to call this specific file from anywhere in the file system with a bit more control over where the migrations end up.

This is a first pass at making the CLI API a wee bit more usable.

---

If you're open to it, I'd be willing to put together an all-around upgraded CLI API. Maybe something like:

```
sql-migrations migrate
sql-migrations rollback
sql-migrations create
```

with the ability to specify configs in a few different ways:

- some kind of config file (defaulting to something such as `__dirname/.sqlmigrationsrc`)
- the ability to override the location of the config file in the command like `sql-migrations migrate --config .myconfig`
- specifying each individual option using command line flags, such as `--migrations-dir ./my-migrations`, with aliases that match the `psql` aliases (i.e. `-d --dbname`)

What do you think?