### PR TITLE
Fix migrations issue

### DIFF
--- a/commands/run-migrations-command.js
+++ b/commands/run-migrations-command.js
@@ -33,7 +33,7 @@ module.exports = function (migrationProvider, adapter, minMigrationTime, logger)
 function getPending(migrationsList, appliedMigrationIds, minMigrationTime) {
     var pending = [];
     migrationsList.forEach(function (migration) {
-        var id = migration.match(/^(\d+)/)[0];
+        var id = +migration.match(/^(\d+)/)[0];
         if ((!minMigrationTime || id >= minMigrationTime) && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
             pending.push(migration);
         }

--- a/commands/run-migrations-command.js
+++ b/commands/run-migrations-command.js
@@ -34,7 +34,7 @@ function getPending(migrationsList, appliedMigrationIds, minMigrationTime) {
     var pending = [];
     migrationsList.forEach(function (migration) {
         var id = +migration.match(/^(\d+)/)[0];
-        if ((!minMigrationTime || id >= minMigrationTime) && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
+        if ((!minMigrationTime || id >= minMigrationTime) && !~appliedMigrationIds.indexOf(id) && /^\d+\_up.*$/.test(migration)) {
             pending.push(migration);
         }
     });


### PR DESCRIPTION
__migrations__ id property is BIGINT

this returns `migration.match(/^(\d+)/)[0];` a string
so this appliedMigrationIds.indexOf(id) fails

