### PR TITLE
feat: ignore unrelated files in migration directory

### DIFF
--- a/commands/run-migrations-command.js
+++ b/commands/run-migrations-command.js
@@ -33,7 +33,12 @@ module.exports = function (migrationProvider, adapter, minMigrationTime, logger)
 function getPending(migrationsList, appliedMigrationIds, minMigrationTime) {
     var pending = [];
     migrationsList.forEach(function (migration) {
-        var id = migration.match(/^(\d+)/)[0];
+        var idMatch = migration.match(/^(\d+)/);
+        if (!idMatch) {
+          console.log(`Ignoring file ${migration}, it does not match the naming pattern.`);
+          return;
+        }
+        var id = idMatch[0];
         if ((!minMigrationTime || id >= minMigrationTime) && !~appliedMigrationIds.indexOf(id) && migration.match(/^\d+\_up.*$/)) {
             pending.push(migration);
         }

--- a/migration-provider.js
+++ b/migration-provider.js
@@ -4,7 +4,8 @@ var path = require('path');
 module.exports = function (config) {
     return {
         getMigrationsList: function () {
-            return fs.readdirSync(config.migrationsDir);
+            return fs.readdirSync(config.migrationsDir)
+                .filter(filename => filename.endsWith('.sql'));
         },
         /**
          * @param {Array} migrationsList list of filenames


### PR DESCRIPTION
When the migration directory contains additional files, `sql-migrations` aborts with a rather cryptic error:

```
    ERROR: TypeError: Cannot read properties of null (reading '0')
        at /path/to/project/node_modules/sql-migrations/commands/run-migrations-command.js:36:43
```

The reason is twofold:
* `migration-provider.js` returns all files in the migration directory (the result of `fs.readdir` unconditionally and unfiltered.
* `commands/run-migrations-command.js` matches on the file name to extract the migration ID/timestamp and has no check if there is a match or not, it just uses the first match unconditionally.

This is especially annoying when working on migrations with editors that create a temporary file in the current directory, like vim does (vim automatically creates `.1662812614706_up_my_migration.sql.swp` when working on `1662812614706_up_my_migration.sql` in the same directory). There might be other editors with similar behavior.

The fix in this change is also twofold: 
* `migration-provider.js` now filters on files that end with `.sql` and will ignore other files. This might be debatable. Do people also use other file formats/suffixes? I am fine with dropping this change if you feel this is too restrictive. 
* `commands/run-migrations-command.js` now checks if there is actually a match and prints a useful warning about the file that didn't match the expected pattern. Even with the first fix in `migration-provider.js` in place, this is still useful if there is an `.sql` file in the directory that does not match the expected file name pattern.
